### PR TITLE
DEV-5060: Clean up extracted files after S3 upload

### DIFF
--- a/src/extraction.py
+++ b/src/extraction.py
@@ -133,6 +133,7 @@ def extract(path: str) -> Union[Success, ErrorModel]:
             filepath,
             settings.EXTRACTED_S3_BUCKET_NAME
         )
+        filepath.unlink(missing_ok=True)
         return Success(key=key)
     except RuntimeError as ex:
         return logger.generate_error(


### PR DESCRIPTION
We were getting a `[Errno 28] No space left on device` coming from the Lambda function.

Following https://stackoverflow.com/a/48347749/14683209, we now delete the extracted file from the Lambda storage after uploading it to S3.