### PR TITLE
DEV-5128: Detect image-based documents

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -63,11 +63,10 @@ ENV: Environment = (Environment(os.environ["ENV"])
 class Settings(BaseSettings):
     """Settings."""
 
-    EXTRACTION_VERSION: str = "1.0"
-
     #######
     # AWS #
     #######
+
     # Set variables below as Environment Variables from the AWS Console.
     AWS_REGION_NAME: str
     AWS_S3_ACCESS_KEY_ID: str

--- a/src/extraction.py
+++ b/src/extraction.py
@@ -25,8 +25,8 @@ import hashlib
 import json
 import time
 import urllib.parse
-from typing import Union
 from pathlib import Path
+from typing import Union, Dict
 
 import fitz
 from fitz import sRGB_to_rgb
@@ -34,6 +34,7 @@ from botocore.exceptions import BotoCoreError
 
 from config import settings
 from utils import s3_connection
+from utils.document_types import DocType
 from utils.logging_utils import Logger, ErrorModel
 from utils.models import Success
 
@@ -80,6 +81,10 @@ def extract(path: str) -> Union[Success, ErrorModel]:
             if not toc:
                 toc = None
             pages = []
+            block_type_counts: Dict[str, int] = {
+                "text": 0,
+                "image": 0
+            }
             for number, raw_page in enumerate(doc, 1):
                 page = dict(
                     {"number": number,
@@ -88,6 +93,7 @@ def extract(path: str) -> Union[Success, ErrorModel]:
                 )
                 for block in page["blocks"]:
                     if block["type"] == 0:  # text
+                        block_type_counts["text"] += 1
                         for line in block["lines"]:
                             for span in line["spans"]:
                                 # Encode the text in UTF-8. If the text cannot
@@ -102,6 +108,7 @@ def extract(path: str) -> Union[Success, ErrorModel]:
                                     r, g, b = sRGB_to_rgb(span["color"])
                                     span["color"] = f"#{r:02x}{g:02x}{b:02x}"
                     elif block["type"] == 1:  # image
+                        block_type_counts["image"] += 1
                         # For now, we don't return images to reduce the response
                         # size.
                         block["image"] = ""
@@ -117,23 +124,32 @@ def extract(path: str) -> Union[Success, ErrorModel]:
                 ))
                 pages.append(page)
         elapsed_seconds = time.perf_counter() - start_time
-        extracted_doc = {
-            "path": path,
-            "hash": doc_hash,
-            "elapsed_seconds": round(elapsed_seconds, 2),
-            "extraction_version": settings.EXTRACTION_VERSION,
-            "toc": toc,
-            "pages": pages
-        }
-        filepath = (Path("/tmp")/f"{path}").with_suffix('.json')
-        filepath.parents[0].mkdir(parents=True, exist_ok=True)
-        with open(filepath, "w", encoding="utf-8") as f:
-            json.dump(extracted_doc, f)
-        key = s3_connection.upload_file(
-            filepath,
-            settings.EXTRACTED_S3_BUCKET_NAME
+        doc_type: DocType = DocType.determine(
+            block_type_counts["text"],
+            block_type_counts["image"]
         )
-        return Success(key=key)
+        if doc_type in (DocType.EMPTY, DocType.IMAGE_BASED):
+            key = None
+        elif doc_type is DocType.TEXT_BASED:
+            extracted_doc = {
+                "path": path,
+                "hash": doc_hash,
+                "elapsed_seconds": round(elapsed_seconds, 2),
+                "toc": toc,
+                "pages": pages
+            }
+            filepath = (Path("/tmp")/f"{path}").with_suffix('.json')
+            filepath.parents[0].mkdir(parents=True, exist_ok=True)
+            with open(filepath, "w", encoding="utf-8") as f:
+                json.dump(extracted_doc, f)
+            key = s3_connection.upload_file(
+                filepath,
+                settings.EXTRACTED_S3_BUCKET_NAME
+            )
+            filepath.unlink(missing_ok=True)
+        else:
+            raise NotImplementedError(f'unrecognized doc type "{doc_type}"')
+        return Success(doc_hash=doc_hash, key=key, doc_type=doc_type)
     except RuntimeError as ex:
         return logger.generate_error(
             path=path,

--- a/src/utils/document_types.py
+++ b/src/utils/document_types.py
@@ -1,0 +1,63 @@
+# Copyright (C) 2023 KNOWRON GmbH <ask@knowron.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# For license information on the libraries used, see LICENSE.
+
+from enum import Enum
+
+from config import settings
+
+
+class DocType(Enum):
+    """The type of document.
+
+    Attributes:
+        EMPTY:
+            An empty document.
+        TEXT_BASED:
+            A text-based document.
+        IMAGE_BASED:
+            An image-based document.
+    """
+
+    EMPTY = "empty"
+    TEXT_BASED = "text_based"
+    IMAGE_BASED = "image_based"
+
+    @classmethod
+    def determine(
+        cls,
+        text_block_count: int,
+        image_block_count: int
+    ):
+        """Determine the type of a document.
+
+        Args:
+            text_block_count (:obj:`int`):
+                The number of text blocks in the document.
+            image_block_count (:obj:`int`):
+                The number of image blocks in the document.
+
+        Returns:
+            :obj:`DocType`: The type of the document.
+        """
+        total_block_count = text_block_count + image_block_count
+        if total_block_count == 0:
+            return cls.EMPTY
+        text_block_ratio = text_block_count / total_block_count
+        image_block_ratio = image_block_count / total_block_count
+        if text_block_ratio > image_block_ratio:
+            return cls.TEXT_BASED
+        return cls.IMAGE_BASED

--- a/src/utils/models.py
+++ b/src/utils/models.py
@@ -24,6 +24,7 @@ from pydantic import validator
 
 from config import Environment, ENV
 from utils.base_model import CamelModel
+from utils.document_types import DocType
 
 
 class OriginatingSystem(Enum):
@@ -98,8 +99,15 @@ class Success(CamelModel):
     Attributes:
         success (:obj:`bool`):
             Whether the extraction succeeded. Always set to ``True``.
-        key (:obj:`str`):
-            The S3 key to the extracted contents.
+        doc_hash (:obj:`str`):
+            The hash of the document binary.
+        key (:obj:`Optional[str]`):
+            The S3 key to the extracted contents. If :obj:`None`, the document
+            is image-based.
+        doc_type (:obj:`.document_types.DocType`):
+            The type of the document.
     """
     success: bool = True
-    key: str
+    doc_hash: str
+    key: Optional[str]
+    doc_type: DocType


### PR DESCRIPTION
This PR enables image-based doc recognition.

If `n_image_blocks / n_text_blocks >= 0.90`, we consider a document to be image-based.