### PR TITLE
Also take into account images referenced at page level & drawings to determine doc type

### DIFF
--- a/src/extraction.py
+++ b/src/extraction.py
@@ -91,6 +91,9 @@ def extract(path: str) -> Union[Success, ErrorModel]:
                      "rotation": raw_page.rotation},
                     **raw_page.get_text("dict")
                 )
+                # Images can appear referenced at the page level or included
+                # as an image block (handled below).
+                block_type_counts["image"] += len(raw_page.get_images())
                 for block in page["blocks"]:
                     if block["type"] == 0:  # text
                         block_type_counts["text"] += 1

--- a/src/extraction.py
+++ b/src/extraction.py
@@ -83,7 +83,8 @@ def extract(path: str) -> Union[Success, ErrorModel]:
             pages = []
             block_type_counts: Dict[str, int] = {
                 "text": 0,
-                "image": 0
+                "image": 0,
+                "drawing": 0,
             }
             for number, raw_page in enumerate(doc, 1):
                 page = dict(
@@ -115,13 +116,15 @@ def extract(path: str) -> Union[Success, ErrorModel]:
                         # For now, we don't return images to reduce the response
                         # size.
                         block["image"] = ""
+                page_drawings = raw_page.get_drawings()
+                block_type_counts["drawing"] = len(page_drawings)
                 # `dict.fromkeys` is used to remove duplicates keeping the order.
                 page["line_drawings"] = list(dict.fromkeys(
                     (round(item[1][0], 2),  # x0
                      round(item[1][1], 2),  # y0
                      round(item[2][0], 2),  # x1
                      round(item[2][1], 2))  # y1
-                    for drawing in raw_page.get_drawings()
+                    for drawing in page_drawings
                     for item in drawing["items"]
                     if item[0] == "l"
                 ))
@@ -130,6 +133,7 @@ def extract(path: str) -> Union[Success, ErrorModel]:
         doc_type: DocType = DocType.determine(
             block_type_counts["text"],
             block_type_counts["image"]
+            block_type_counts["drawing"]
         )
         if doc_type in (DocType.EMPTY, DocType.IMAGE_BASED):
             key = None

--- a/src/extraction.py
+++ b/src/extraction.py
@@ -81,7 +81,7 @@ def extract(path: str) -> Union[Success, ErrorModel]:
             if not toc:
                 toc = None
             pages = []
-            block_type_counts: Dict[str, int] = {
+            element_type_counts: Dict[str, int] = {
                 "text": 0,
                 "image": 0,
                 "drawing": 0,
@@ -94,10 +94,10 @@ def extract(path: str) -> Union[Success, ErrorModel]:
                 )
                 # Images can appear referenced at the page level or included
                 # as an image block (handled below).
-                block_type_counts["image"] += len(raw_page.get_images())
+                element_type_counts["image"] += len(raw_page.get_images())
                 for block in page["blocks"]:
                     if block["type"] == 0:  # text
-                        block_type_counts["text"] += 1
+                        element_type_counts["text"] += 1
                         for line in block["lines"]:
                             for span in line["spans"]:
                                 # Encode the text in UTF-8. If the text cannot
@@ -112,12 +112,12 @@ def extract(path: str) -> Union[Success, ErrorModel]:
                                     r, g, b = sRGB_to_rgb(span["color"])
                                     span["color"] = f"#{r:02x}{g:02x}{b:02x}"
                     elif block["type"] == 1:  # image
-                        block_type_counts["image"] += 1
+                        element_type_counts["image"] += 1
                         # For now, we don't return images to reduce the response
                         # size.
                         block["image"] = ""
                 page_drawings = raw_page.get_drawings()
-                block_type_counts["drawing"] = len(page_drawings)
+                element_type_counts["drawing"] = len(page_drawings)
                 # `dict.fromkeys` is used to remove duplicates keeping the order.
                 page["line_drawings"] = list(dict.fromkeys(
                     (round(item[1][0], 2),  # x0
@@ -131,9 +131,9 @@ def extract(path: str) -> Union[Success, ErrorModel]:
                 pages.append(page)
         elapsed_seconds = time.perf_counter() - start_time
         doc_type: DocType = DocType.determine(
-            block_type_counts["text"],
-            block_type_counts["image"]
-            block_type_counts["drawing"]
+            element_type_counts["text"],
+            element_type_counts["image"],
+            element_type_counts["drawing"]
         )
         if doc_type in (DocType.EMPTY, DocType.IMAGE_BASED):
             key = None

--- a/src/utils/document_types.py
+++ b/src/utils/document_types.py
@@ -39,31 +39,31 @@ class DocType(Enum):
     @classmethod
     def determine(
         cls,
-        text_block_count: int,
-        image_block_count: int
-        drawing_block_count: int
+        text_count: int,
+        image_count: int,
+        drawing_count: int
     ):
         """Determine the type of a document.
 
         Args:
-            text_block_count (:obj:`int`):
+            text_count (:obj:`int`):
                 The number of text blocks in the document.
-            image_block_count (:obj:`int`):
-                The number of image blocks in the document.
-            drawing_block_count (:obj:`int`):
+            image_count (:obj:`int`):
+                The number of images in the document.
+            drawing_count (:obj:`int`):
                 The number of drawings in the document.
 
         Returns:
             :obj:`DocType`: The type of the document.
         """
-        total_block_count: int = (
-            text_block_count + image_block_count + drawing_block_count
+        total_count: int = (
+            text_count + image_count + drawing_count
         )
-        if total_block_count == 0:
+        if total_count == 0:
             return cls.EMPTY
-        text_block_ratio = text_block_count / total_block_count
-        image_block_ratio = image_block_count / total_block_count
-        if text_block_ratio > image_block_ratio:
+        text_ratio = text_count / total_count
+        image_ratio = image_count / total_count
+        if text_ratio > image_ratio:
             return cls.TEXT_BASED
         # Note: If there is no text but there are drawings, we also consider
         # the doc image-based.

--- a/src/utils/document_types.py
+++ b/src/utils/document_types.py
@@ -41,6 +41,7 @@ class DocType(Enum):
         cls,
         text_block_count: int,
         image_block_count: int
+        drawing_block_count: int
     ):
         """Determine the type of a document.
 
@@ -49,15 +50,21 @@ class DocType(Enum):
                 The number of text blocks in the document.
             image_block_count (:obj:`int`):
                 The number of image blocks in the document.
+            drawing_block_count (:obj:`int`):
+                The number of drawings in the document.
 
         Returns:
             :obj:`DocType`: The type of the document.
         """
-        total_block_count = text_block_count + image_block_count
+        total_block_count: int = (
+            text_block_count + image_block_count + drawing_block_count
+        )
         if total_block_count == 0:
             return cls.EMPTY
         text_block_ratio = text_block_count / total_block_count
         image_block_ratio = image_block_count / total_block_count
         if text_block_ratio > image_block_ratio:
             return cls.TEXT_BASED
+        # Note: If there is no text but there are drawings, we also consider
+        # the doc image-based.
         return cls.IMAGE_BASED


### PR DESCRIPTION
Images can also be referenced at the page level. These images will not appear in `page.get_text("dict")`. Instead, they need to be accessed through `page.get_images()`.

Furthermore, we have detected that some documents include embedded drawings, but no text or images images are returned by either `page.get_text("dict")` or `page.get_images()`. As a workaround, if a document contains no text/images, but it does contain drawings, we treat it as image-based.